### PR TITLE
Use HTTPS to resolve dependencies in Maven Build

### DIFF
--- a/iguana.commons/pom.xml
+++ b/iguana.commons/pom.xml
@@ -58,12 +58,12 @@
 	<distributionManagement>
 		<repository>
 			<id>maven.aksw.internal</id>
-			<url>http://maven.aksw.org/archiva/repository/internal</url>
+			<url>https://maven.aksw.org/archiva/repository/internal</url>
 		</repository>
 		<snapshotRepository>
 			<id>maven.aksw.snapshots</id>
 			<name>AKSW Snapshot Repository</name>
-			<url>http://maven.aksw.org/archiva/repository/snapshots</url>
+			<url>https://maven.aksw.org/archiva/repository/snapshots</url>
 		</snapshotRepository>
 	</distributionManagement>
 

--- a/iguana.datagenerator/dependency-reduced-pom.xml
+++ b/iguana.datagenerator/dependency-reduced-pom.xml
@@ -73,12 +73,12 @@
     <repository>
       <id>maven.aksw.internal</id>
       <name>University Leipzig, AKSW Maven2 Repository</name>
-      <url>http://maven.aksw.org/repository/internal</url>
+      <url>https://maven.aksw.org/repository/internal</url>
     </repository>
     <repository>
       <id>maven.aksw.snapshots</id>
       <name>University Leipzig, AKSW Maven2 Repository</name>
-      <url>http://maven.aksw.org/repository/snapshots</url>
+      <url>https://maven.aksw.org/repository/snapshots</url>
     </repository>
   </repositories>
   <dependencies>

--- a/iguana.datagenerator/pom.xml
+++ b/iguana.datagenerator/pom.xml
@@ -36,12 +36,12 @@
         <repository>
             <id>maven.aksw.internal</id>
             <name>University Leipzig, AKSW Maven2 Repository</name>
-            <url>http://maven.aksw.org/repository/internal</url>
+            <url>https://maven.aksw.org/repository/internal</url>
         </repository>
         <repository>
             <id>maven.aksw.snapshots</id>
             <name>University Leipzig, AKSW Maven2 Repository</name>
-            <url>http://maven.aksw.org/repository/snapshots</url>
+            <url>https://maven.aksw.org/repository/snapshots</url>
         </repository>
     </repositories>
 

--- a/iguana.resultprocessor/pom.xml
+++ b/iguana.resultprocessor/pom.xml
@@ -170,12 +170,12 @@
 		<repository>
 			<id>maven.aksw.internal</id>
 			<name>University Leipzig, AKSW Maven2 Repository</name>
-			<url>http://maven.aksw.org/archiva/repository/internal</url>
+			<url>https://maven.aksw.org/archiva/repository/internal</url>
 		</repository>
 		<repository>
 			<id>maven.aksw.snapshots</id>
 			<name>University Leipzig, AKSW Maven2 Repository</name>
-			<url>http://maven.aksw.org/archiva/repository/snapshots</url>
+			<url>https://maven.aksw.org/archiva/repository/snapshots</url>
 		</repository>
 	</repositories>
 

--- a/iguana.webcontroller/pom.xml
+++ b/iguana.webcontroller/pom.xml
@@ -189,12 +189,12 @@
 		<repository>
 			<id>maven.aksw.internal</id>
 			<name>University Leipzig, AKSW Maven2 Repository</name>
-			<url>http://maven.aksw.org/archiva/repository/internal</url>
+			<url>https://maven.aksw.org/archiva/repository/internal</url>
 		</repository>
 		<repository>
 			<id>maven.aksw.snapshots</id>
 			<name>University Leipzig, AKSW Maven2 Repository</name>
-			<url>http://maven.aksw.org/archiva/repository/snapshots</url>
+			<url>https://maven.aksw.org/archiva/repository/snapshots</url>
 		</repository>
 	</repositories>
 


### PR DESCRIPTION
Resolve dependencies of the AKSW repository over https.