### PR TITLE
make result files lexically orderable

### DIFF
--- a/iguana.resultprocessor/src/main/java/org/aksw/iguana/rp/storage/impl/NTFileStorage.java
+++ b/iguana.resultprocessor/src/main/java/org/aksw/iguana/rp/storage/impl/NTFileStorage.java
@@ -37,11 +37,18 @@ public class NTFileStorage extends TripleBasedStorage {
 		Calendar now = Calendar.getInstance();
 		
 		this.file = new StringBuilder();
-		file.append("results_").append(now.get(Calendar.DAY_OF_MONTH)).append("-")
-			.append(now.get(Calendar.MONTH)+1).append("-")
-			.append(now.get(Calendar.YEAR)).append("_")
-			.append(now.get(Calendar.HOUR_OF_DAY)).append("-")
-			.append(now.get(Calendar.MINUTE)).append(".nt");
+		file.append("results_")
+			.append(
+				String.format("%d-%02d-%02d_%02d-%02d.%03d",
+					now.get(Calendar.YEAR),
+					now.get(Calendar.MONTH) + 1,
+					now.get(Calendar.DAY_OF_MONTH),
+					now.get(Calendar.HOUR_OF_DAY),
+					now.get(Calendar.MINUTE),
+					now.get(Calendar.MILLISECOND)
+				)
+			)
+			.append(".nt");
 	}
 
 	/**


### PR DESCRIPTION
was `results_{DD}-{MM}-{YYYY}_{HH}-{mm}.nt` and is now `results_{YYYY}-{MM}-{DD}_{HH}-{mm}.{ms:03}.nt`

Also, leading 0 were not enforced, e.g. the old format produced 1 instead of 01 for the first day of a month.

I think it will make our life much easier during benchmarking. If you think so too and it passed the tests, please merge. 

**note:*** beware! the text in the commit message is wrong. The text in this pull request is correct. ↑