### PR TITLE
fixed end restriction for noqm

### DIFF
--- a/iguana.corecontroller/src/main/java/org/aksw/iguana/cc/tasks/impl/Stresstest.java
+++ b/iguana.corecontroller/src/main/java/org/aksw/iguana/cc/tasks/impl/Stresstest.java
@@ -220,7 +220,7 @@ public class Stresstest extends AbstractTask {
 				// if so send all results buffered
 				sendWorkerResult(worker);
 			}
-			loopSleep(10);
+			loopSleep(100);
 		}
 		LOGGER.debug("Sending stop signal to workers");
 		// tell all workers to stop sending properties, thus the await termination will

--- a/iguana.corecontroller/src/main/java/org/aksw/iguana/cc/tasks/impl/Stresstest.java
+++ b/iguana.corecontroller/src/main/java/org/aksw/iguana/cc/tasks/impl/Stresstest.java
@@ -141,6 +141,9 @@ public class Stresstest extends AbstractTask {
 		for(int i=0;i<threads;i++) {
 			workerConfig.put("workerID", baseID+i);
 			Worker worker = new WorkerFactory().create(className, workerConfig);
+			if(this.noOfQueryMixes!=null){
+				worker.endAtNoOfQueryMixes(noOfQueryMixes);
+			}
 			workersToAddTo.add(worker);
 		}
 		return threads;
@@ -217,7 +220,7 @@ public class Stresstest extends AbstractTask {
 				// if so send all results buffered
 				sendWorkerResult(worker);
 			}
-			loopSleep(100);
+			loopSleep(10);
 		}
 		LOGGER.debug("Sending stop signal to workers");
 		// tell all workers to stop sending properties, thus the await termination will
@@ -260,6 +263,7 @@ public class Stresstest extends AbstractTask {
 		if(props == null){
 			return;
 		}
+
 		for (Properties results : props) {
 			try {
 

--- a/iguana.corecontroller/src/main/java/org/aksw/iguana/cc/worker/AbstractWorker.java
+++ b/iguana.corecontroller/src/main/java/org/aksw/iguana/cc/worker/AbstractWorker.java
@@ -224,7 +224,7 @@ public abstract class AbstractWorker implements Worker {
 			executedQueries++;
 
 			//
-			if(getExecutedQueries()*1.0 % getNoOfQueries() == 0 ){
+			if(getExecutedQueries() % getNoOfQueries() == 0 ){
 				LOGGER.info("Worker executed {} queryMixes", getExecutedQueries()*1.0/getNoOfQueries());
 			}
 		}

--- a/iguana.corecontroller/src/main/java/org/aksw/iguana/cc/worker/Worker.java
+++ b/iguana.corecontroller/src/main/java/org/aksw/iguana/cc/worker/Worker.java
@@ -76,5 +76,14 @@ public interface Worker extends Runnable{
 	 * @param noOfQueryMixes
 	 * @return
 	 */
-	boolean hasExecutedNoOfQueryMixes(double noOfQueryMixes);
+	boolean hasExecutedNoOfQueryMixes(Long noOfQueryMixes);
+
+
+	/**
+	 * Sets the end restriction
+	 *
+	 * @param noOfQueryMixes
+	 */
+	void endAtNoOfQueryMixes(Long noOfQueryMixes);
+
 }

--- a/iguana.corecontroller/src/main/java/org/aksw/iguana/cc/worker/impl/UPDATEWorker.java
+++ b/iguana.corecontroller/src/main/java/org/aksw/iguana/cc/worker/impl/UPDATEWorker.java
@@ -135,7 +135,7 @@ public class UPDATEWorker extends HttpPostWorker {
 	 * @return
 	 */
 	@Override
-	public boolean hasExecutedNoOfQueryMixes(double noOfQueryMixes){
+	public boolean hasExecutedNoOfQueryMixes(Long noOfQueryMixes){
 		return getExecutedQueries() / (getNoOfQueries() * 1.0) >= 1;
 	}
 

--- a/iguana.corecontroller/src/test/java/org/aksw/iguana/cc/worker/HTTPWorkerTest.java
+++ b/iguana.corecontroller/src/test/java/org/aksw/iguana/cc/worker/HTTPWorkerTest.java
@@ -214,7 +214,7 @@ public class HTTPWorkerTest {
         getWorker.stopSending();
         executorService.shutdownNow();
         // check correct executedQueries
-        int expectedSize=4;
+        long expectedSize=4;
         if(isPost){
             expectedSize=2;
         }
@@ -225,7 +225,7 @@ public class HTTPWorkerTest {
             assertEquals(queryHash, p.get(COMMON.QUERY_HASH));
         }
         assertEquals(expectedSize, results.size());
-        for(int i=1;i<expectedSize;i++) {
+        for(long i=1;i<expectedSize;i++) {
             assertTrue(getWorker.hasExecutedNoOfQueryMixes(i));
         }
         assertFalse(getWorker.hasExecutedNoOfQueryMixes(expectedSize+1));


### PR DESCRIPTION
minor version 3.2.1 
* fixing that if the endpoint is fast enough squeezing another query into the execution if NoQM end restricition is set
* Logging if a Worker executed a query mix