### PR TITLE
Upgrade to junit 5

### DIFF
--- a/iguana.commons/pom.xml
+++ b/iguana.commons/pom.xml
@@ -47,12 +47,6 @@
 
 	<dependencies>
 		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-			<version>4.13.1</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
 			<groupId>commons-configuration</groupId>
 			<artifactId>commons-configuration</artifactId>
 			<version>1.10</version>
@@ -91,6 +85,18 @@
 			<groupId>org.reflections</groupId>
 			<artifactId>reflections</artifactId>
 			<version>0.9.9</version>
+		</dependency>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter</artifactId>
+			<version>5.9.2</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.junit.vintage</groupId>
+			<artifactId>junit-vintage-engine</artifactId>
+			<version>5.9.2</version>
+			<scope>test</scope>
 		</dependency>
 	</dependencies>
 	<!-- DISTRIBUTION MANAGEMENT -->

--- a/iguana.commons/pom.xml
+++ b/iguana.commons/pom.xml
@@ -98,6 +98,12 @@
 			<version>5.9.2</version>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<version>4.13.2</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 	<!-- DISTRIBUTION MANAGEMENT -->
 	<distributionManagement>

--- a/iguana.corecontroller/pom.xml
+++ b/iguana.corecontroller/pom.xml
@@ -111,6 +111,12 @@
 		<version>5.9.2</version>
 		<scope>test</scope>
 	</dependency>
+	<dependency>
+		<groupId>junit</groupId>
+		<artifactId>junit</artifactId>
+		<version>4.13.2</version>
+		<scope>test</scope>
+	</dependency>
 
 
 </dependencies>

--- a/iguana.corecontroller/pom.xml
+++ b/iguana.corecontroller/pom.xml
@@ -78,12 +78,6 @@
 	</dependency>
 	<!-- JUnit -->
 	<dependency>
-		<groupId>junit</groupId>
-		<artifactId>junit</artifactId>
-		<version>4.13.1</version>
-		<scope>test</scope>
-	</dependency>
-	<dependency>
 		<groupId>org.simpleframework</groupId>
 		<artifactId>simple</artifactId>
 		<version>5.1.6</version>
@@ -105,9 +99,21 @@
 			<artifactId>iguana.commons</artifactId>
 			<version>${revision}</version>
 		</dependency>
+	<dependency>
+		<groupId>org.junit.jupiter</groupId>
+		<artifactId>junit-jupiter</artifactId>
+		<version>5.9.2</version>
+		<scope>test</scope>
+	</dependency>
+	<dependency>
+		<groupId>org.junit.vintage</groupId>
+		<artifactId>junit-vintage-engine</artifactId>
+		<version>5.9.2</version>
+		<scope>test</scope>
+	</dependency>
 
 
-	</dependencies>
+</dependencies>
 <build>
 		<plugins>
 			<plugin>

--- a/iguana.corecontroller/src/test/java/org/aksw/iguana/cc/model/QueryResultHashKeyTest.java
+++ b/iguana.corecontroller/src/test/java/org/aksw/iguana/cc/model/QueryResultHashKeyTest.java
@@ -9,6 +9,7 @@ import java.util.Collection;
 import java.util.UUID;
 
 import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 @RunWith(Parameterized.class)
 public class QueryResultHashKeyTest {

--- a/iguana.corecontroller/src/test/java/org/aksw/iguana/cc/model/QueryResultHashKeyTest.java
+++ b/iguana.corecontroller/src/test/java/org/aksw/iguana/cc/model/QueryResultHashKeyTest.java
@@ -9,7 +9,6 @@ import java.util.Collection;
 import java.util.UUID;
 
 import static org.junit.Assert.*;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 @RunWith(Parameterized.class)
 public class QueryResultHashKeyTest {

--- a/iguana.resultprocessor/pom.xml
+++ b/iguana.resultprocessor/pom.xml
@@ -79,6 +79,12 @@
 			<version>5.9.2</version>
 			<scope>test</scope>
 		</dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.13.2</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/iguana.resultprocessor/pom.xml
+++ b/iguana.resultprocessor/pom.xml
@@ -63,15 +63,21 @@
 		</dependency>
 
 		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-			<version>4.13.1</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
 			<groupId>org.aksw</groupId>
 			<artifactId>iguana.commons</artifactId>
 			<version>${revision}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter</artifactId>
+			<version>5.9.2</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.junit.vintage</groupId>
+			<artifactId>junit-vintage-engine</artifactId>
+			<version>5.9.2</version>
+			<scope>test</scope>
 		</dependency>
 	</dependencies>
 


### PR DESCRIPTION
This pr upgrades junit to junit 5. I should note that there might be some problems with running the tests in Intellij and the vintage-engine from junit 5. For some reason on my machine Intellij used junit 4.10 for the corecontroller module, which caused problems with the vintage-engine.

Actually migrating the tests to junit 5 should be done later.