### PR TITLE
Fix the calculation of the penalized metrics

### DIFF
--- a/iguana.resultprocessor/src/main/java/org/aksw/iguana/rp/metrics/impl/AvgQPSMetric.java
+++ b/iguana.resultprocessor/src/main/java/org/aksw/iguana/rp/metrics/impl/AvgQPSMetric.java
@@ -48,14 +48,15 @@ public class AvgQPSMetric extends QPSMetric {
             for(Object queryID : value.keySet()){
                 Object[] resArr = (Object[]) value.get(queryID);
                 Double qps = (long)resArr[1]*1.0/((double)resArr[0]/1000.0);
-                Double penalizedQPS = (long)resArr[1]*1.0/((double)resArr[7]/1000.0);
-                map.putIfAbsent(queryID, new Number[]{Double.valueOf(0), Long.valueOf(0), Double.valueOf(0)});
+                Double penalizedQPS = ((long)resArr[1] + (long)resArr[2]) *1.0/((double)resArr[7]/1000.0);
+                map.putIfAbsent(queryID, new Number[]{Double.valueOf(0), Long.valueOf(0), Long.valueOf(0), Double.valueOf(0)});
 
                 Number[] current =map.get(queryID);
                 Long succ = (long)resArr[1]+(Long)current[1];
+                Long fail = (long)resArr[2]+(Long)current[2];
                 Double time = (double)resArr[0]+(Double)current[0];
-                Double penTime = (double)resArr[7]+(Double)current[2];
-                map.put(queryID, new Number[]{time, succ, penTime});
+                Double penTime = (double)resArr[7]+(Double)current[3];
+                map.put(queryID, new Number[]{time, succ, fail, penTime});
                 avgQps+=qps;
                 penalizedAvgQps+=penalizedQPS;
             }
@@ -71,7 +72,7 @@ public class AvgQPSMetric extends QPSMetric {
         Double penalizedAvgQps=0.0;
         for(Object queryID : map.keySet()) {
             Double qps = (Long)map.get(queryID)[1]*1.0/((Double)map.get(queryID)[0]/1000.0);
-            Double penalizedQPS = (long)map.get(queryID)[1]*1.0/((double)map.get(queryID)[2]/1000.0);
+            Double penalizedQPS = ((long)map.get(queryID)[1] + (long)map.get(queryID)[2]) *1.0/((double)map.get(queryID)[3]/1000.0);
             avgQps+=qps;
             penalizedAvgQps+=penalizedQPS;
         }

--- a/iguana.resultprocessor/src/main/java/org/aksw/iguana/rp/metrics/impl/AvgQPSMetric.java
+++ b/iguana.resultprocessor/src/main/java/org/aksw/iguana/rp/metrics/impl/AvgQPSMetric.java
@@ -47,8 +47,8 @@ public class AvgQPSMetric extends QPSMetric {
             Double penalizedAvgQps=0.0;
             for(Object queryID : value.keySet()){
                 Object[] resArr = (Object[]) value.get(queryID);
-                Double qps = (long)resArr[1]*1.0/((double)resArr[0]/1000.0);
-                Double penalizedQPS = ((long)resArr[1] + (long)resArr[2]) *1.0/((double)resArr[7]/1000.0);
+                Double qps = (long) resArr[1]/*success*/ / (double) resArr[0]/*time*/ / 1000.0/*ms to s*/;
+                Double penalizedQPS = ((long) resArr[1]/*success*/ + (long) resArr[2]/*failure*/) / (double) resArr[7]/*penalizedTime*/ / 1000.0/*ms to s*/;
                 map.putIfAbsent(queryID, new Number[]{Double.valueOf(0), Long.valueOf(0), Long.valueOf(0), Double.valueOf(0)});
 
                 Number[] current =map.get(queryID);

--- a/iguana.resultprocessor/src/main/java/org/aksw/iguana/rp/metrics/impl/QPSMetric.java
+++ b/iguana.resultprocessor/src/main/java/org/aksw/iguana/rp/metrics/impl/QPSMetric.java
@@ -90,7 +90,8 @@ public class QPSMetric extends AbstractMetric {
 		Properties tmp = getDataFromContainer(extra);
 		if(tmp!=null && tmp.containsKey(queryID)){
 			Object[] oldArr = (Object[]) tmp.get(queryID);
-			oldArr[0] = (double) oldArr[0] + time;
+			if (success > 0)
+				oldArr[0] = (double) oldArr[0] + time;
 			oldArr[1] = (long) oldArr[1] + success;
 			oldArr[2] = (long) oldArr[2] + failure;
 			if((long)oldArr[3]<size) {

--- a/iguana.resultprocessor/src/main/java/org/aksw/iguana/rp/metrics/impl/QPSMetric.java
+++ b/iguana.resultprocessor/src/main/java/org/aksw/iguana/rp/metrics/impl/QPSMetric.java
@@ -102,7 +102,7 @@ public class QPSMetric extends AbstractMetric {
 			oldArr[7] = (double) oldArr[7] + penalizedTime;
 		}
 		else if(tmp!=null){
-			Object[] resArr = {time, success, failure, size, timeout, unknown, wrongCode, penalizedTime, queryHash};
+			Object[] resArr = {time/*0*/, success/*1*/, failure/*2*/, size/*3*/, timeout/*4*/, unknown/*5*/, wrongCode/*6*/, penalizedTime/*7*/, queryHash/*8*/};
 			tmp.put(queryID, resArr);
 		}
 		else{
@@ -175,8 +175,8 @@ public class QPSMetric extends AbstractMetric {
 			Object[] resArr = (Object[]) value.get(queryID);
 			if(map!=null)
 				mergeResults(map, queryID, resArr);
-			Double qps = (long)resArr[1]*1.0/((double)resArr[0]/1000.0);
-			Double pqps = ((long)resArr[1] + (long)resArr[2]) * 1.0 / ((double)resArr[7]/1000.0);
+			Double qps = (long) resArr[1]/*success*/ / (double) resArr[0]/*time*/ / 1000.0/*ms to s*/;
+			Double pqps = ((long)resArr[1]/*success*/ + (long)resArr[2]/*failure*/) / ((double)resArr[7]/*penalizedTime*//1000.0/*ms to s*/);
 
 			Resource query = ResourceFactory.createResource(subjectParent.getURI()+"/"+queryID);
 			m.add(subjectParent, queryProperty, query);

--- a/iguana.resultprocessor/src/main/java/org/aksw/iguana/rp/metrics/impl/QPSMetric.java
+++ b/iguana.resultprocessor/src/main/java/org/aksw/iguana/rp/metrics/impl/QPSMetric.java
@@ -176,7 +176,7 @@ public class QPSMetric extends AbstractMetric {
 			if(map!=null)
 				mergeResults(map, queryID, resArr);
 			Double qps = (long)resArr[1]*1.0/((double)resArr[0]/1000.0);
-			Double pqps = (long)resArr[1]*1.0/((double)resArr[7]/1000.0);
+			Double pqps = ((long)resArr[1] + (long)resArr[2]) * 1.0 / ((double)resArr[7]/1000.0);
 
 			Resource query = ResourceFactory.createResource(subjectParent.getURI()+"/"+queryID);
 			m.add(subjectParent, queryProperty, query);

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
         <major.minor.version>${major.version}.${minor.version}</major.minor.version>
         <major.version>3</major.version>
         <minor.version>3</minor.version>
-        <build.version>2</build.version>
+        <build.version>3</build.version>
     </properties>
     <distributionManagement>
         <repository>


### PR DESCRIPTION
The penalized metrics were only calculated with the successful executions, instead of every execution.