### PR TITLE
SPARQLLanguageProcessor: fix getContentTypeVal

### DIFF
--- a/iguana.corecontroller/src/main/java/org/aksw/iguana/cc/lang/impl/SPARQLLanguageProcessor.java
+++ b/iguana.corecontroller/src/main/java/org/aksw/iguana/cc/lang/impl/SPARQLLanguageProcessor.java
@@ -7,11 +7,9 @@ import org.aksw.iguana.cc.utils.SPARQLQueryStatistics;
 import org.aksw.iguana.commons.annotation.Shorthand;
 import org.aksw.iguana.commons.constants.COMMON;
 import org.aksw.iguana.rp.vocab.Vocab;
-import org.apache.commons.lang.StringUtils;
 import org.apache.http.Header;
 import org.apache.http.HeaderElement;
 import org.apache.http.HttpEntity;
-import org.apache.http.NameValuePair;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.jena.ext.com.google.common.hash.HashCode;
 import org.apache.jena.ext.com.google.common.hash.Hashing;
@@ -31,14 +29,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
 import org.w3c.dom.NodeList;
-import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 import java.io.*;
-import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 
@@ -103,20 +99,9 @@ public class SPARQLLanguageProcessor extends AbstractLanguageProcessor implement
 
 
     public static String getContentTypeVal(Header header) {
-        for (HeaderElement el : header.getElements()) {
-            NameValuePair cTypePair = el.getParameterByName("Content-Type");
-
-            if (cTypePair != null && !cTypePair.getValue().isEmpty()) {
-                return cTypePair.getValue();
-            }
-        }
-        int index = header.toString().indexOf("Content-Type");
-        if (index >= 0) {
-            String ret = header.toString().substring(index + "Content-Type".length() + 1);
-            if (ret.contains(";")) {
-                return ret.substring(0, ret.indexOf(";")).trim();
-            }
-            return ret.trim();
+        final HeaderElement[] elements = header.getElements();
+        if (elements.length > 0) {
+            return elements[0].getName();
         }
         return "application/sparql-results+json";
     }

--- a/iguana.corecontroller/src/test/java/org/aksw/iguana/cc/lang/SPARQLLanguageProcessorTest.java
+++ b/iguana.corecontroller/src/test/java/org/aksw/iguana/cc/lang/SPARQLLanguageProcessorTest.java
@@ -1,6 +1,7 @@
 package org.aksw.iguana.cc.lang;
 
 import org.aksw.iguana.cc.lang.impl.SPARQLLanguageProcessor;
+import org.apache.http.message.BasicHeader;
 import org.apache.jena.ext.com.google.common.collect.Lists;
 import org.apache.jena.query.Query;
 import org.apache.jena.query.QueryFactory;
@@ -140,5 +141,13 @@ public class SPARQLLanguageProcessorTest {
         expected.remove(actual);
         actual.write(new FileWriter("test2.nt"),  "N-TRIPLE");
         assertEquals(0, expected.size());
+    }
+
+    @Test
+    public void testGetContentTypeVal() {
+        assertEquals("application/sparql-results+json",
+                SPARQLLanguageProcessor.getContentTypeVal(new BasicHeader("content-type", "application/sparql-results+json;charset=utf-8")));
+        assertEquals("application/sparql-results+xml",
+                SPARQLLanguageProcessor.getContentTypeVal(new BasicHeader("content-type", "application/sparql-results+xml;charset=utf-8")));
     }
 }


### PR DESCRIPTION
Use the name of the first HeaderElement to extract the actual content-type.
This is similar to what is done by ContentType::get(HttpEntity).