### PR TITLE
Fix performance issues

### DIFF
--- a/src/main/java/org/aksw/iguana/cc/metrics/impl/AggregatedExecutionStatistics.java
+++ b/src/main/java/org/aksw/iguana/cc/metrics/impl/AggregatedExecutionStatistics.java
@@ -6,6 +6,7 @@ import org.aksw.iguana.cc.worker.HttpWorker;
 import org.aksw.iguana.commons.rdf.IONT;
 import org.aksw.iguana.commons.rdf.IPROP;
 import org.aksw.iguana.commons.rdf.IRES;
+import org.aksw.iguana.commons.time.TimeUtils;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
 import org.apache.jena.rdf.model.Resource;
@@ -17,9 +18,6 @@ import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-
-import static org.aksw.iguana.commons.time.TimeUtils.createTypedDurationLiteral;
-import static org.aksw.iguana.commons.time.TimeUtils.toXSDDurationInSeconds;
 
 public class AggregatedExecutionStatistics extends Metric implements ModelWritingMetric {
 
@@ -81,8 +79,8 @@ public class AggregatedExecutionStatistics extends Metric implements ModelWritin
         m.add(queryRes, IPROP.timeOuts, ResourceFactory.createTypedLiteral(timeOuts));
         m.add(queryRes, IPROP.wrongCodes, ResourceFactory.createTypedLiteral(wrongCodes));
         m.add(queryRes, IPROP.unknownException, ResourceFactory.createTypedLiteral(unknownExceptions));
-        // m.add(queryRes, IPROP.totalTime, ResourceFactory.createTypedLiteral(toXSDDurationInSeconds(totalTime)));
-        m.add(queryRes, IPROP.totalTime, createTypedDurationLiteral(totalTime));
+        m.add(queryRes, IPROP.totalTime, TimeUtils.createTypedDurationLiteralInSeconds(totalTime));
+        // m.add(queryRes, IPROP.totalTime, TimeUtils.createTypedDurationLiteral(totalTime));
         m.add(queryRes, RDF.type, IONT.executedQuery);
 
         return m;

--- a/src/main/java/org/aksw/iguana/cc/metrics/impl/AggregatedExecutionStatistics.java
+++ b/src/main/java/org/aksw/iguana/cc/metrics/impl/AggregatedExecutionStatistics.java
@@ -18,6 +18,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import static org.aksw.iguana.commons.time.TimeUtils.createTypedDurationLiteral;
 import static org.aksw.iguana.commons.time.TimeUtils.toXSDDurationInSeconds;
 
 public class AggregatedExecutionStatistics extends Metric implements ModelWritingMetric {
@@ -80,7 +81,8 @@ public class AggregatedExecutionStatistics extends Metric implements ModelWritin
         m.add(queryRes, IPROP.timeOuts, ResourceFactory.createTypedLiteral(timeOuts));
         m.add(queryRes, IPROP.wrongCodes, ResourceFactory.createTypedLiteral(wrongCodes));
         m.add(queryRes, IPROP.unknownException, ResourceFactory.createTypedLiteral(unknownExceptions));
-        m.add(queryRes, IPROP.totalTime, ResourceFactory.createTypedLiteral(toXSDDurationInSeconds(totalTime)));
+        // m.add(queryRes, IPROP.totalTime, ResourceFactory.createTypedLiteral(toXSDDurationInSeconds(totalTime)));
+        m.add(queryRes, IPROP.totalTime, createTypedDurationLiteral(totalTime));
         m.add(queryRes, RDF.type, IONT.executedQuery);
 
         return m;

--- a/src/main/java/org/aksw/iguana/cc/query/source/QuerySource.java
+++ b/src/main/java/org/aksw/iguana/cc/query/source/QuerySource.java
@@ -18,8 +18,16 @@ public abstract class QuerySource {
     /** This string represents the path of the file or folder, that contains the queries. */
     final protected Path path;
 
+    /**
+     * This integer represents the hashcode of the file or folder, that contains the queries. It is stored for
+     * performance reasons, so that the hashcode does not have to be calculated every time it is needed.
+     * (It's needed everytime the id of a query is requested.)
+     */
+    final protected int hashCode;
+
     public QuerySource(Path path) {
         this.path = path;
+        this.hashCode = FileUtils.getHashcodeFromFileContent(path);
     }
 
     /**
@@ -50,6 +58,6 @@ public abstract class QuerySource {
 
     @Override
     public int hashCode() {
-        return FileUtils.getHashcodeFromFileContent(this.path);
+        return hashCode;
     }
 }

--- a/src/main/java/org/aksw/iguana/cc/storage/impl/RDFFileStorage.java
+++ b/src/main/java/org/aksw/iguana/cc/storage/impl/RDFFileStorage.java
@@ -1,6 +1,5 @@
 package org.aksw.iguana.cc.storage.impl;
 
-import com.github.jsonldjava.shaded.com.google.common.base.Supplier;
 import org.aksw.iguana.cc.config.elements.StorageConfig;
 import org.aksw.iguana.cc.storage.Storage;
 import org.apache.commons.io.FilenameUtils;
@@ -19,6 +18,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Calendar;
 import java.util.Optional;
+import java.util.function.Supplier;
 
 public class RDFFileStorage implements Storage {
     public record Config(String path) implements StorageConfig {}

--- a/src/main/java/org/aksw/iguana/cc/tasks/impl/Stresstest.java
+++ b/src/main/java/org/aksw/iguana/cc/tasks/impl/Stresstest.java
@@ -92,7 +92,7 @@ public class Stresstest implements Task {
         Calendar startTime = Calendar.getInstance(); // TODO: Calendar is outdated
         var futures = workers.stream().map(HttpWorker::start).toList();
         CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).join();
-        Calendar endTime = Calendar.getInstance(); // TODO: add start and end time for each worker
+        Calendar endTime = Calendar.getInstance();
         for (CompletableFuture<HttpWorker.Result> future : futures) {
             try {
                 results.add(future.get());

--- a/src/main/java/org/aksw/iguana/commons/time/DurationLiteral.java
+++ b/src/main/java/org/aksw/iguana/commons/time/DurationLiteral.java
@@ -1,0 +1,90 @@
+package org.aksw.iguana.commons.time;
+
+import org.apache.jena.datatypes.DatatypeFormatException;
+import org.apache.jena.datatypes.RDFDatatype;
+import org.apache.jena.graph.impl.LiteralLabel;
+import org.apache.jena.vocabulary.XSD;
+
+import java.time.Duration;
+
+/**
+ * Class related to the conversion of Java time objects to RDF literals. This class is used to convert a Java Duration
+ * object to a typed RDF literal. The literal is typed as xsd:duration. This class temporarily fixes an issue with Jena.
+ */
+public class DurationLiteral implements RDFDatatype {
+
+    private final Duration duration;
+
+    public DurationLiteral(Duration duration) {
+        this.duration = duration;
+    }
+
+    public String getLexicalForm() {
+        return duration.toString();
+    }
+
+    @Override
+    public String getURI() {
+        return XSD.getURI() + "#duration";
+    }
+
+    @Override
+    public String unparse(Object value) {
+        return ((DurationLiteral) value).getLexicalForm();
+    }
+
+    @Override
+    public Object parse(String lexicalForm) throws DatatypeFormatException {
+        return new DurationLiteral(Duration.parse(lexicalForm));
+    }
+
+    @Override
+    public boolean isValid(String lexicalForm) {
+        try {
+            Duration.parse(lexicalForm);
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    @Override
+    public boolean isValidValue(Object valueForm) {
+        return valueForm instanceof DurationLiteral;
+    }
+
+    @Override
+    public boolean isValidLiteral(LiteralLabel lit) {
+        return lit.getDatatype() instanceof DurationLiteral;
+    }
+
+    @Override
+    public boolean isEqual(LiteralLabel value1, LiteralLabel value2) {
+        return value1.getDatatype() == value2.getDatatype() && value1.getValue().equals(value2.getValue());
+    }
+
+    @Override
+    public int getHashCode(LiteralLabel lit) {
+        return lit.getValue().hashCode();
+    }
+
+    @Override
+    public Class<?> getJavaClass() {
+        return DurationLiteral.class;
+    }
+
+    @Override
+    public Object cannonicalise(Object value) {
+        return value;
+    }
+
+    @Override
+    public Object extendedTypeDefinition() {
+        return null;
+    }
+
+    @Override
+    public RDFDatatype normalizeSubType(Object value, RDFDatatype dt) {
+        return dt;
+    }
+}

--- a/src/main/java/org/aksw/iguana/commons/time/DurationLiteral.java
+++ b/src/main/java/org/aksw/iguana/commons/time/DurationLiteral.java
@@ -8,8 +8,8 @@ import org.apache.jena.vocabulary.XSD;
 import java.time.Duration;
 
 /**
- * Class related to the conversion of Java time objects to RDF literals. This class is used to convert a Java Duration
- * object to a typed RDF literal. The literal is typed as xsd:duration. This class temporarily fixes an issue with Jena.
+ * This class is used to convert a Java Duration object to a typed RDF literal. The literal is typed as xsd:duration.
+ * This class temporarily fixes an issue with Jena.
  */
 public class DurationLiteral implements RDFDatatype {
 

--- a/src/main/java/org/aksw/iguana/commons/time/DurationLiteral.java
+++ b/src/main/java/org/aksw/iguana/commons/time/DurationLiteral.java
@@ -25,7 +25,7 @@ public class DurationLiteral implements RDFDatatype {
 
     @Override
     public String getURI() {
-        return XSD.getURI() + "#duration";
+        return XSD.getURI() + "duration";
     }
 
     @Override

--- a/src/main/java/org/aksw/iguana/commons/time/TimeUtils.java
+++ b/src/main/java/org/aksw/iguana/commons/time/TimeUtils.java
@@ -22,6 +22,11 @@ public class TimeUtils {
 		return (XSDDuration) new XSDDurationType().parse("PT" + new BigDecimal(BigInteger.valueOf(duration.toNanos()), 9).toPlainString() + "S");
 	}
 
+	public static Literal createTypedDurationLiteralInSeconds(Duration duration) {
+		final var seconds = "PT" + new BigDecimal(BigInteger.valueOf(duration.toNanos()), 9).toPlainString() + "S";
+		return ResourceFactory.createTypedLiteral(seconds, new DurationLiteral(duration));
+	}
+
 	public static Literal createTypedDurationLiteral(Duration duration) {
 		return ResourceFactory.createTypedLiteral(duration.toString(), new DurationLiteral(duration));
 	}

--- a/src/main/java/org/aksw/iguana/commons/time/TimeUtils.java
+++ b/src/main/java/org/aksw/iguana/commons/time/TimeUtils.java
@@ -2,7 +2,6 @@ package org.aksw.iguana.commons.time;
 
 import org.apache.jena.datatypes.xsd.XSDDuration;
 import org.apache.jena.datatypes.xsd.impl.XSDDateTimeStampType;
-import org.apache.jena.datatypes.xsd.impl.XSDDateTimeType;
 import org.apache.jena.datatypes.xsd.impl.XSDDurationType;
 import org.apache.jena.rdf.model.Literal;
 import org.apache.jena.rdf.model.ResourceFactory;
@@ -24,7 +23,7 @@ public class TimeUtils {
 	}
 
 	public static Literal createTypedDurationLiteral(Duration duration) {
-		return ResourceFactory.createTypedLiteral(new XSDDurationType().parse(duration.toString()));
+		return ResourceFactory.createTypedLiteral(duration.toString(), new DurationLiteral(duration));
 	}
 
 	public static Literal createTypedInstantLiteral(Instant time) {

--- a/src/test/java/org/aksw/iguana/cc/query/list/QueryListTest.java
+++ b/src/test/java/org/aksw/iguana/cc/query/list/QueryListTest.java
@@ -7,6 +7,7 @@ import org.aksw.iguana.cc.query.source.impl.FileLineQuerySource;
 import org.aksw.iguana.cc.query.source.impl.FileSeparatorQuerySource;
 import org.aksw.iguana.cc.query.source.impl.FolderQuerySource;
 import org.apache.commons.io.FileUtils;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Named;
@@ -100,9 +101,13 @@ class QueryListTest {
         return out;
     }
 
+    @Test
     public void testIllegalArguments() {
         assertThrows(NullPointerException.class, () -> new InMemQueryList(null));
-        assertThrows(NullPointerException.class, () -> new FileBasedQueryList(null));
+        assertThrows(NullPointerException.class, () -> {
+            final var ql = new FileBasedQueryList(null);
+            ql.size();
+        });
     }
 
     @ParameterizedTest(name = "[{index}] queryListClass={0}, querySourceConfig={1}")


### PR DESCRIPTION
During a test of the new iguana version, I noticed that there were some severe performance issues during the processing of the results, after the stresstest has finished. The biggest issue of it was the jena library and the `canonical` method inside its `XSDDuration` class, which didn't support nanoseconds as decimal digits for the durations. 
This PR aims to circumvent this issue by creating our own LiteralType class, which might not be the best solution.

I've also made the QuerySource cache its hashCode, which also caused some performance issues, as the hashCode is needed everytime the id of a Query from a QueryHandler is retrieved. Caching the QuerySource hashCode shouldn't be a problem though, as we don't expect the hashCode to change itself during the benchmark.