### PR TITLE
Fix request caching

### DIFF
--- a/src/main/java/org/aksw/iguana/cc/utils/http/StreamEntityProducer.java
+++ b/src/main/java/org/aksw/iguana/cc/utils/http/StreamEntityProducer.java
@@ -98,6 +98,10 @@ public class StreamEntityProducer implements AsyncEntityProducer {
 
     @Override
     public void releaseResources() {
+        if (content != null) {
+            content.clear();
+        }
+
         if (currentStream != null) {
             try {
                 currentStream.close();


### PR DESCRIPTION
The byte buffer that stored the content of the request wasn't being reset after the request has been sent.