### PR TITLE
Fix storage of completion target information in results

### DIFF
--- a/src/main/java/org/aksw/iguana/cc/tasks/impl/StresstestResultProcessor.java
+++ b/src/main/java/org/aksw/iguana/cc/tasks/impl/StresstestResultProcessor.java
@@ -130,9 +130,9 @@ public class StresstestResultProcessor {
             m.add(workerRes, IPROP.noOfQueries, ResourceFactory.createTypedLiteral(config.queries().getQueryCount()));
             m.add(workerRes, IPROP.timeOut, TimeUtils.createTypedDurationLiteral(config.timeout()));
             if (config.completionTarget() instanceof HttpWorker.QueryMixes)
-                m.add(taskRes, IPROP.noOfQueryMixes, ResourceFactory.createTypedLiteral(((HttpWorker.QueryMixes) config.completionTarget()).number()));
+                m.add(workerRes, IPROP.noOfQueryMixes, ResourceFactory.createTypedLiteral(((HttpWorker.QueryMixes) config.completionTarget()).number()));
             if (config.completionTarget() instanceof HttpWorker.TimeLimit)
-                m.add(taskRes, IPROP.timeLimit, TimeUtils.createTypedDurationLiteral(((HttpWorker.TimeLimit) config.completionTarget()).duration()));
+                m.add(workerRes, IPROP.timeLimit, TimeUtils.createTypedDurationLiteral(((HttpWorker.TimeLimit) config.completionTarget()).duration()));
             m.add(workerRes, IPROP.connection, connectionRes);
 
             m.add(connectionRes, RDF.type, IONT.connection);


### PR DESCRIPTION
The completion target information was wrongly stored for the task instead its workers.