### PR TITLE
Fix the response body processor timeout message

### DIFF
--- a/src/main/java/org/aksw/iguana/cc/worker/ResponseBodyProcessor.java
+++ b/src/main/java/org/aksw/iguana/cc/worker/ResponseBodyProcessor.java
@@ -72,7 +72,10 @@ public class ResponseBodyProcessor {
             return responseDataMetrics;
         }
 
-        LOGGER.info(MessageFormat.format("Shutting down ResponseBodyProcessor with {0} min timeout to finish processing. {1} tasks remaining.", timeout.toMinutes() + "." + (timeout.toSecondsPart() / 6), executor.getQueue().size()));
+        LOGGER.info(MessageFormat.format("Shutting down ResponseBodyProcessor with {0}min {1}s timeout to finish processing. {2} tasks remaining.",
+                timeout.toMinutes(), 
+                String.format("%02d", timeout.toSecondsPart()),
+                executor.getQueue().size()));
         boolean noTimeout;
         try {
             executor.shutdown();

--- a/src/main/java/org/aksw/iguana/cc/worker/ResponseBodyProcessor.java
+++ b/src/main/java/org/aksw/iguana/cc/worker/ResponseBodyProcessor.java
@@ -72,7 +72,7 @@ public class ResponseBodyProcessor {
             return responseDataMetrics;
         }
 
-        LOGGER.info(MessageFormat.format("Shutting down ResponseBodyProcessor with {0} min timeout to finish processing. {1} tasks remaining.", timeout.toMinutes() + "." + (timeout.toSecondsPart() / (double) 60), executor.getQueue().size()));
+        LOGGER.info(MessageFormat.format("Shutting down ResponseBodyProcessor with {0} min timeout to finish processing. {1} tasks remaining.", timeout.toMinutes() + "." + (timeout.toSecondsPart() / 6), executor.getQueue().size()));
         boolean noTimeout;
         try {
             executor.shutdown();


### PR DESCRIPTION
The timeout message for the response body processor hash a bad formatting for the time.