### PR TITLE
Make linearly executing workers start at different positions

### DIFF
--- a/src/main/java/org/aksw/iguana/cc/query/handler/QueryHandler.java
+++ b/src/main/java/org/aksw/iguana/cc/query/handler/QueryHandler.java
@@ -157,6 +157,7 @@ public class QueryHandler {
     final protected QueryList queryList;
 
     private int workerCount = 0; // give every worker inside the same worker config an offset seed
+    private int totalWorkerCount = 0;
 
     final protected int hashCode;
 
@@ -184,6 +185,10 @@ public class QueryHandler {
                     new FileReadingQueryList(querySource);
         }
         this.hashCode = queryList.hashCode();
+    }
+
+    public void setTotalWorkerCount(int workers) {
+        this.totalWorkerCount = workers;
     }
 
     private QueryList initializeTemplateQueryHandler(QuerySource templateSource) throws IOException {
@@ -238,7 +243,7 @@ public class QueryHandler {
 
     public QuerySelector getQuerySelectorInstance() {
         switch (config.order()) {
-            case LINEAR -> { return new LinearQuerySelector(queryList.size()); }
+            case LINEAR -> { return new LinearQuerySelector(queryList.size(), totalWorkerCount != 0 ? (queryList.size() * workerCount++) / totalWorkerCount : 0); }
             case RANDOM -> { return new RandomQuerySelector(queryList.size(), config.seed() + workerCount++); }
         }
 

--- a/src/main/java/org/aksw/iguana/cc/query/selector/impl/LinearQuerySelector.java
+++ b/src/main/java/org/aksw/iguana/cc/query/selector/impl/LinearQuerySelector.java
@@ -32,6 +32,7 @@ public class LinearQuerySelector extends QuerySelector {
 
     /**
      * Return the current index. This is the index of the last returned query.
+     * If no query was returned yet, the method will return -1.
      *
      * @return the current index
      */

--- a/src/main/java/org/aksw/iguana/cc/query/selector/impl/LinearQuerySelector.java
+++ b/src/main/java/org/aksw/iguana/cc/query/selector/impl/LinearQuerySelector.java
@@ -14,25 +14,29 @@ public class LinearQuerySelector extends QuerySelector {
 
     public LinearQuerySelector(int size) {
         super(size);
-        index = -1;
+        index = 0;
+    }
+
+    public LinearQuerySelector(int size, int startIndex) {
+        super(size);
+        index = startIndex;
     }
 
     @Override
     public int getNextIndex() {
-        index++;
         if (index >= this.size) {
             index = 0;
         }
-        return index;
+        return index++;
     }
 
     /**
-     * Return the current index. This is the index of the last returned query. If no query was returned yet, it returns
-     * -1.
-     * @return
+     * Return the current index. This is the index of the last returned query.
+     *
+     * @return the current index
      */
     @Override
     public int getCurrentIndex() {
-        return index;
+        return index - 1;
     }
 }

--- a/src/main/java/org/aksw/iguana/cc/tasks/impl/Stresstest.java
+++ b/src/main/java/org/aksw/iguana/cc/tasks/impl/Stresstest.java
@@ -102,7 +102,7 @@ public class Stresstest implements Task {
     public void run() {
         if (!warmupWorkers.isEmpty()) {
             SPARQLProtocolWorker.initHttpClient(warmupWorkers.size());
-            var warmupResults = executeWorkers(warmupWorkers); // warmup results will be dismissed
+            executeWorkers(warmupWorkers); // warmup results will be dismissed
             SPARQLProtocolWorker.closeHttpClient();
         }
         SPARQLProtocolWorker.initHttpClient(workers.size());

--- a/src/main/java/org/aksw/iguana/cc/tasks/impl/Stresstest.java
+++ b/src/main/java/org/aksw/iguana/cc/tasks/impl/Stresstest.java
@@ -45,6 +45,15 @@ public class Stresstest implements Task {
 
         // initialize workers
         if (config.warmupWorkers() != null) {
+            // initialize query handlers
+            // count the number of workers for each query handler
+            final var queryHandlers = config.warmupWorkers.stream().map(HttpWorker.Config::queries).distinct().toList();
+            queryHandlers.stream().map(qh1 ->
+                            List.of(qh1, config.warmupWorkers.stream()
+                                    .map(HttpWorker.Config::queries)
+                                    .filter(qh1::equals)
+                                    .count()))
+                    .forEach(list -> ((QueryHandler) list.get(0)).setTotalWorkerCount((int) (long) list.get(1)));
             long workerId = 0;
             for (HttpWorker.Config workerConfig : config.warmupWorkers()) {
                 for (int i = 0; i < workerConfig.number(); i++) {
@@ -55,6 +64,15 @@ public class Stresstest implements Task {
         }
 
         for (HttpWorker.Config workerConfig : config.workers()) {
+            // initialize query handlers
+            // count the number of workers for each query handler
+            final var queryHandlers = config.workers.stream().map(HttpWorker.Config::queries).distinct().toList();
+            queryHandlers.stream().map(qh1 ->
+                            List.of(qh1, config.workers.stream()
+                                    .filter(w -> w.queries().equals(qh1))
+                                    .mapToInt(HttpWorker.Config::number)
+                                    .sum()))
+                    .forEach(list -> ((QueryHandler) list.get(0)).setTotalWorkerCount((int) list.get(1)));
             long workerId = 0;
             for (int i = 0; i < workerConfig.number(); i++) {
                 var responseBodyProcessor = (workerConfig.parseResults()) ? responseBodyProcessorInstances.getProcessor(workerConfig.acceptHeader()) : null;
@@ -83,31 +101,10 @@ public class Stresstest implements Task {
 
     public void run() {
         if (!warmupWorkers.isEmpty()) {
-            // initialize query handlers
-            // count the number of workers for each query handler
-            final var queryHandlers = warmupWorkers.stream().map(w -> w.config().queries()).distinct().toList();
-            queryHandlers.stream().map(qh1 ->
-                    List.of(qh1, warmupWorkers.stream()
-                            .map(HttpWorker::config)
-                            .map(HttpWorker.Config::queries)
-                            .filter(qh1::equals)
-                            .count()))
-                    .forEach(list -> ((QueryHandler) list.get(0)).setTotalWorkerCount((int) (long) list.get(1)));
             SPARQLProtocolWorker.initHttpClient(warmupWorkers.size());
             var warmupResults = executeWorkers(warmupWorkers); // warmup results will be dismissed
             SPARQLProtocolWorker.closeHttpClient();
         }
-
-        // initialize query handlers
-        // count the number of workers for each query handler
-        final var queryHandlers = workers.stream().map(w -> w.config().queries()).distinct().toList();
-        queryHandlers.stream().map(qh1 ->
-                        List.of(qh1, workers.stream()
-                                .map(HttpWorker::config)
-                                .map(HttpWorker.Config::queries)
-                                .filter(qh1::equals)
-                                .count()))
-                .forEach(list -> ((QueryHandler) list.get(0)).setTotalWorkerCount((int) (long) list.get(1)));
         SPARQLProtocolWorker.initHttpClient(workers.size());
         var results = executeWorkers(workers);
         SPARQLProtocolWorker.closeHttpClient();

--- a/src/main/java/org/aksw/iguana/cc/worker/impl/SPARQLProtocolWorker.java
+++ b/src/main/java/org/aksw/iguana/cc/worker/impl/SPARQLProtocolWorker.java
@@ -270,7 +270,7 @@ public class SPARQLProtocolWorker extends HttpWorker {
         try {
             request = requestFactory.buildHttpRequest(queryHandle);
         } catch (IOException | URISyntaxException e) {
-            return createFailedResultBeforeRequest(config.queries().getQuerySelectorInstance().getCurrentIndex(), e);
+            return createFailedResultBeforeRequest(querySelector.getCurrentIndex(), e);
         }
 
         // execute the request

--- a/src/test/java/org/aksw/iguana/cc/query/selector/impl/LinearQuerySelectorTest.java
+++ b/src/test/java/org/aksw/iguana/cc/query/selector/impl/LinearQuerySelectorTest.java
@@ -26,4 +26,18 @@ public class LinearQuerySelectorTest {
         final var size = 0;
         assertThrows(IllegalArgumentException.class, () -> new LinearQuerySelector(size));
     }
+
+    @Test
+    public void testStartingIndex() {
+        final var size = 5;
+        final var startIndex = 3;
+        final var linearQuerySelector = new LinearQuerySelector(size, startIndex);
+        // -1, because the next index hasn't been requested yet
+        assertEquals(startIndex - 1, linearQuerySelector.getCurrentIndex());
+        for (int i = 0; i < 10; i++) {
+            int currentIndex = linearQuerySelector.getNextIndex();
+            assertEquals((i + startIndex) % size, currentIndex);
+            assertEquals(currentIndex, linearQuerySelector.getCurrentIndex());
+        }
+    }
 }


### PR DESCRIPTION
This pull request makes changes so that multiple workers that execute the same queries linearly, start at different positions.
The starting positions are equally distanced from each other.

### Query Handling Enhancements:

* [`src/main/java/org/aksw/iguana/cc/query/handler/QueryHandler.java`](diffhunk://#diff-9a5e1eadd71482cada7feae9ee933dd12c62112a8c5548e4c1c86c7b99176bfbR160): Added a `totalWorkerCount` field and a method to set this value. Updated the `getQuerySelectorInstance` method to use this field for the `LinearQuerySelector` initialization. [[1]](diffhunk://#diff-9a5e1eadd71482cada7feae9ee933dd12c62112a8c5548e4c1c86c7b99176bfbR160) [[2]](diffhunk://#diff-9a5e1eadd71482cada7feae9ee933dd12c62112a8c5548e4c1c86c7b99176bfbR190-R193) [[3]](diffhunk://#diff-9a5e1eadd71482cada7feae9ee933dd12c62112a8c5548e4c1c86c7b99176bfbL241-R246)

### Query Selector Improvements:

* [`src/main/java/org/aksw/iguana/cc/query/selector/impl/LinearQuerySelector.java`](diffhunk://#diff-6a76323ed269971f62258de495a664ea785020c4666cf53a4d25375aaf376048L17-R40): Modified the `LinearQuerySelector` to support an optional starting index and adjusted the `getNextIndex` and `getCurrentIndex` methods accordingly.

### Worker Initialization Fixes:

* [`src/main/java/org/aksw/iguana/cc/tasks/impl/Stresstest.java`](diffhunk://#diff-ccb14858c9c4dcce36017cf028fdf99a0a5f7e9681f1d681bed577a5247104a8R5): Updated the `Stresstest` class to initialize query handlers and count the number of workers for each query handler during both warmup and main execution phases. [[1]](diffhunk://#diff-ccb14858c9c4dcce36017cf028fdf99a0a5f7e9681f1d681bed577a5247104a8R5) [[2]](diffhunk://#diff-ccb14858c9c4dcce36017cf028fdf99a0a5f7e9681f1d681bed577a5247104a8R48-R56) [[3]](diffhunk://#diff-ccb14858c9c4dcce36017cf028fdf99a0a5f7e9681f1d681bed577a5247104a8R67-R75) [[4]](diffhunk://#diff-ccb14858c9c4dcce36017cf028fdf99a0a5f7e9681f1d681bed577a5247104a8L86-L89)

### Bug Fixes:

* [`src/main/java/org/aksw/iguana/cc/worker/impl/SPARQLProtocolWorker.java`](diffhunk://#diff-de29e8baf834d272b515e906813d739f2e310324169311d147df54ca5897786dL273-R273): Fixed a bug in the `executeHttpRequest` method to correctly use the `querySelector`'s current index.

### Testing Enhancements:

* [`src/test/java/org/aksw/iguana/cc/query/selector/impl/LinearQuerySelectorTest.java`](diffhunk://#diff-e5138a189b2a80b197a1a2618a5b286b370a56abdb26bfe5653eb7e3427e65daR29-R42): Added a test case to verify the functionality of the `LinearQuerySelector` with a starting index.