### PR TITLE
Add logging option for successful queries

### DIFF
--- a/src/main/java/org/aksw/iguana/cc/controller/MainController.java
+++ b/src/main/java/org/aksw/iguana/cc/controller/MainController.java
@@ -40,6 +40,9 @@ public class MainController {
 
         @Parameter(names = {"--version", "-v"}, description = "Outputs the version number of the program and result ontology.")
         private boolean version;
+
+        @Parameter(names = {"--log-success", "-ls"}, description = "Log successful queries.")
+        public static boolean logSuccess = false;
     }
 
     private static final Logger LOGGER = LoggerFactory.getLogger(MainController.class);

--- a/src/main/java/org/aksw/iguana/cc/worker/impl/SPARQLProtocolWorker.java
+++ b/src/main/java/org/aksw/iguana/cc/worker/impl/SPARQLProtocolWorker.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import net.jpountz.xxhash.StreamingXXHash64;
 import net.jpountz.xxhash.XXHashFactory;
 import org.aksw.iguana.cc.config.elements.ConnectionConfig;
+import org.aksw.iguana.cc.controller.MainController;
 import org.aksw.iguana.cc.query.handler.QueryHandler;
 import org.aksw.iguana.cc.utils.http.RequestFactory;
 import org.aksw.iguana.cc.worker.ResponseBodyProcessor;
@@ -468,10 +469,12 @@ public class SPARQLProtocolWorker extends HttpWorker {
 
     private void logExecution(ExecutionStats execution) {
         switch (execution.endState()) {
-            case SUCCESS -> LOGGER.debug("{}\t:: Successfully executed query: [queryID={}].", this, execution.queryID());
+            case SUCCESS -> {
+                if (MainController.Args.logSuccess) LOGGER.info("{}\t:: Successfully executed query: [queryID={}, duration={}].", this, execution.queryID(), execution.duration());
+            }
             case TIMEOUT -> LOGGER.warn("{}\t:: Timeout during query execution: [queryID={}, duration={}].", this, execution.queryID(), execution.duration()); // TODO: look for a possibility to add the query string for better logging
             case HTTP_ERROR -> LOGGER.warn("{}\t:: HTTP Error occurred during query execution: [queryID={}, httpError={}].", this, execution.queryID(), execution.httpStatusCode().orElse(-1));
-            case MISCELLANEOUS_EXCEPTION -> LOGGER.warn("{}\t:: Miscellaneous exception occurred during query execution: [queryID={}, exception={}].", this, execution.queryID(), execution.error().orElse(null));
+            case MISCELLANEOUS_EXCEPTION -> LOGGER.warn("{}\t:: Miscellaneous exception occurred during query execution: [queryID={}].", this, execution.queryID(), execution.error().orElse(null));
         }
     }
 


### PR DESCRIPTION
The option can be set with `-ls` or `--log-success`, the default therefore is to not log them for now.

@nkaralis