### PR TITLE
Fix version check workflow and limit to pull requests on main

### DIFF
--- a/.github/workflows/check_version.yml
+++ b/.github/workflows/check_version.yml
@@ -1,6 +1,9 @@
 # Checks if version number has been updated 
 name: Version Check
-on: pull_request
+on:
+  pull_request:
+    branches:
+      - main
 
 jobs:
   lint:


### PR DESCRIPTION
There seems to be a problem with the version check workflow. Maybe this will fix it. Also I don't think that the versions should be checked on feature branches, but only on pull request on main. I changed that as well.